### PR TITLE
enable classic elb raw table to handle user-agent with embedded quote

### DIFF
--- a/athena_glue_service_logs/elb_classic.py
+++ b/athena_glue_service_logs/elb_classic.py
@@ -64,7 +64,7 @@ class ELBRawCatalog(ALBRawCatalog):
             "SerdeInfo": {
                 "SerializationLibrary": "com.amazonaws.glue.serde.GrokSerDe",
                 "Parameters": {
-                    "input.format": "%{NOTSPACE:time} %{NOTSPACE:elb} %{NOTSPACE:client_ip_port} %{NOTSPACE:target_ip_port} %{BASE10NUM:request_processing_time:double} %{BASE10NUM:target_processing_time:double} %{BASE10NUM:response_processing_time:double} %{NOTSPACE:elb_status_code} %{NOTSPACE:target_status_code} %{NOTSPACE:received_bytes:int} %{NOTSPACE:sent_bytes:int} \"%{NOTSPACE:request_verb} %{NOTSPACE:request_url} %{INSIDE_QS:request_proto}\" \"%{INSIDE_QS:user_agent}\" %{NOTSPACE:ssl_cipher} %{NOTSPACE:ssl_protocol}",  # noqa pylint: disable=C0301
+                    "input.format": "%{NOTSPACE:time} %{NOTSPACE:elb} %{NOTSPACE:client_ip_port} %{NOTSPACE:target_ip_port} %{BASE10NUM:request_processing_time:double} %{BASE10NUM:target_processing_time:double} %{BASE10NUM:response_processing_time:double} %{NOTSPACE:elb_status_code} %{NOTSPACE:target_status_code} %{NOTSPACE:received_bytes:int} %{NOTSPACE:sent_bytes:int} \"%{NOTSPACE:request_verb} %{NOTSPACE:request_url} %{INSIDE_QS:request_proto}\" %{QS:user_agent} %{NOTSPACE:ssl_cipher} %{NOTSPACE:ssl_protocol}",  # noqa pylint: disable=C0301
                     "input.grokCustomPatterns": "INSIDE_QS ([^\\\"]*)"
                 }
             },


### PR DESCRIPTION
*Description of changes:*

The existing GrokSerDe input.format for classic elbs occasionally does not match lines in the elb logs so athena returns empty results. I tracked down the issue to being caused by requests which have quotes in the user-agent field.
Here's an example log entry from one of my elbs:
`2018-12-13T15:16:57.132252Z elb-name 93.113.124.199:44444 10.25.30.166:80 0.000048 0.000504 0.000025 301 301 0 178 "GET http://10.25.25.42:80/ HTTP/1.0" "\"nlpproject.info research\"" - -`

The problem comes from the INSIDE_QS grok pattern which explicitly excludes strings with quotes in them. I found that changing this field to use a regular QS grok pattern fixes the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
