### PR TITLE
Small tweak to assertion error for python 3 to be more clear

### DIFF
--- a/athena_glue_service_logs/__init__.py
+++ b/athena_glue_service_logs/__init__.py
@@ -14,5 +14,5 @@
 """athena_glue_service_logs is a library for converting AWS Service Logs into a more Athena-friendly format"""
 import sys
 
-# Ensure python version 2.7.x - Glue only runs 2.7
-assert sys.version_info[:2] == (2, 7), "Glue currently supports Python 2.7 only."
+# Ensure python version 2.7.x as this was written before glue supported python 3
+assert sys.version_info[:2] == (2, 7), "athena-glue-service-logs currently only supports python 2.7."


### PR DESCRIPTION
*Issue #, if available:*
Short enough of a change, so just recommending it, will link to the ticket where python3 support is mentioned.
This was confusing for our team at first, since glue does now support python 3. While waiting on python3 support, I'd recommend this change to avoid similar confusion.

*Description of changes:*
Updated assertion error message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
